### PR TITLE
fixed the search path for the catch.hpp

### DIFF
--- a/func_collection.sh
+++ b/func_collection.sh
@@ -820,7 +820,7 @@ function install_eigen {
 # ======================
 
 function install_catch {
-  if [ ! -e ${MARS_DEV_ROOT}"/install/include/catch.hpp" ]; then
+  if [ ! -e ${MARS_DEV_ROOT}"/install/include/catch/catch.hpp" ]; then
     pushd . > /dev/null 2>&1
     mkdir ${MARS_DEV_ROOT}/install/include/catch
     cp ${MARS_DEV_ROOT}/external/catch.hpp ${MARS_DEV_ROOT}/install/include/catch/catch.hpp 


### PR DESCRIPTION
issue: the update procedure failed because catch.hpp was found at an outdated location and thus not installed to the new location
solution: updated the search location

@malter 
